### PR TITLE
Show the size in bytes of the code

### DIFF
--- a/src/components/Slider.vue
+++ b/src/components/Slider.vue
@@ -7,7 +7,9 @@
     <div :class="$style.info">
       Current Plugin:
       <span :class="$style.plugin">{{currentPlugin}}</span>, Current Visitor:
-      <span :class="$style.visitor">{{currentVisitor}}</span>
+      <span :class="$style.visitor">{{currentVisitor}}</span>, Size:
+      <span :class="$style.visitor">{{currentSize}}</span>
+
     </div>
   </div>
 </template>
@@ -21,6 +23,10 @@ export default {
     }
   },
   computed: {
+    currentSize() {
+      return this.$store.state.transitions[this.current].size;
+    },
+
     currentPlugin() {
       return this.$store.state.transitions[this.current].pluginAlias;
     },

--- a/src/store/babel-worker.js
+++ b/src/store/babel-worker.js
@@ -2,7 +2,6 @@ import registerPromiseWorker from "promise-worker-transferable/register";
 import babelPresetBabili from "babel-preset-babili";
 import generate from "babel-generator";
 import { str2ab, ab2str } from "./buffer-utils";
-
 importScripts("//unpkg.com/babel-standalone@6.24.2/babel.min.js");
 
 registerPromiseWorker(function babelTransform(
@@ -34,7 +33,7 @@ registerPromiseWorker(function babelTransform(
             code,
             pluginAlias,
             visitorType,
-            currentNode: args[0].node.type
+            currentNode: args[0].node.type,
           });
         }
         callback.call(this, ...args);

--- a/src/store/buffer-utils.js
+++ b/src/store/buffer-utils.js
@@ -11,3 +11,5 @@ export function str2ab(str) {
   }
   return buf;
 }
+
+

--- a/src/store/byte-utils.js
+++ b/src/store/byte-utils.js
@@ -1,0 +1,28 @@
+// Source: https://github.com/babel/website/blob/master/js/repl/Utils.js
+
+const sizes = ["Bytes", "kB", "MB", "GB", "TB", "PB", "EB"];
+
+export function prettySize(size) {
+  const places = 1;
+  let mysize;
+  
+  sizes.forEach((unit, id) => {
+    const s = Math.pow(1024, id);
+    let fixed;
+    if (size >= s) {
+      fixed = String((size / s).toFixed(places));
+      if (fixed.indexOf(".0") === fixed.length - 2) {
+        fixed = fixed.slice(0, -2);
+      }
+      mysize = `${fixed} ${unit}`;
+    }
+  });
+  
+  // zero handling
+  // always prints in Bytes
+  if (!mysize) {
+    const unit = sizes[0];
+    mysize = `0 ${unit}`;
+  }
+  return mysize;
+}

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -2,6 +2,7 @@ import Vue from "vue";
 import Vuex from "vuex";
 import PromiseWorker from "promise-worker-transferable";
 import { str2ab, ab2str } from "./buffer-utils";
+import { prettySize } from "./byte-utils"
 
 Vue.use(Vuex);
 
@@ -13,7 +14,8 @@ function getSource(code) {
   return {
     code,
     pluginAlias: "source",
-    visitorType: "enter"
+    visitorType: "enter",
+    size: prettySize(new Blob([code], { type: "text/plain" }).size),
   };
 }
 
@@ -90,11 +92,12 @@ export default new Vuex.Store({
         .postMessage(message, [message.source])
         .then(result => {
           const transitions = result.transitions.map(
-            ({ code, pluginAlias, visitorType, currentNode }) => ({
+            ({ code, pluginAlias, visitorType, currentNode, size }) => ({
               code: ab2str(code),
               pluginAlias,
               visitorType,
-              currentNode
+              currentNode,
+              size: prettySize(new Blob([code], { type: "text/plain" }).size)
             })
           );
 


### PR DESCRIPTION
Hello, @boopathi. 
One the way I have worked on REPL, I'd like to add a new feature, the size in bytes of the code in babel-time-travel. Hope you like! 🙏

<img width="948" alt="screen shot 2018-07-26 at 7 05 12 pm" src="https://user-images.githubusercontent.com/6011401/43256196-00ae58f8-9107-11e8-98ed-c1602ca415ec.png">
